### PR TITLE
Improved Error documentation and added Errorpopup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vscode
 .idea
 .prettierrc

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import "styles/add/Starscape.scss";
 import useStompWebSocket from "./components/hooks/useStompWebSocket";
 import { Client } from "@stomp/stompjs";
 import { getDomain } from "./helpers/getDomain";
+import {ErrorProvider} from "./helpers/api";
 
 /**
  * Happy coding!
@@ -24,13 +25,15 @@ const App = () => {
     const stompWebSocketHook = useStompWebSocket(client);
 
     return (
-        <div>
-            <Header height="100" />
-            <AppRouter stompWebSocketHook={stompWebSocketHook}/>
-            <div className="starscape">
-                <Starscape />
+        <ErrorProvider>
+            <div>
+                <Header height="100" />
+                <AppRouter stompWebSocketHook={stompWebSocketHook}/>
+                <div className="starscape">
+                    <Starscape />
+                </div>
             </div>
-        </div>
+        </ErrorProvider>
     );
 };
 

--- a/src/components/popup-ui/ErrorPopup.tsx
+++ b/src/components/popup-ui/ErrorPopup.tsx
@@ -6,6 +6,7 @@ import PropTypes from "prop-types";
 
 const ErrorPopup = ({ErrorInfo, resetError}) => {
 
+
     let [errorPopup, setErrorPopup] = useState(true)
     const Errordata = ErrorInfo.split("\n");
     const errormessage = Errordata[4];

--- a/src/components/popup-ui/ErrorPopup.tsx
+++ b/src/components/popup-ui/ErrorPopup.tsx
@@ -4,7 +4,7 @@ import BaseContainer from "components/ui/BaseContainer";
 import "styles/popup-ui/ErrorPopup.scss";
 import PropTypes from "prop-types";
 
-const ErrorPopup = ({ErrorInfo}) => {
+const ErrorPopup = ({ErrorInfo, resetError}) => {
 
     let [errorPopup, setErrorPopup] = useState(true)
     const Errordata = ErrorInfo.split("\n");
@@ -14,6 +14,11 @@ const ErrorPopup = ({ErrorInfo}) => {
     const error = Errordata[3];
     const errormessage = Errordata[4];
 
+    const handleClose = () => {
+        setErrorPopup(false);
+        resetError();
+    }
+
     if (errorPopup) return (
         <BaseContainer className="errorpopup container">
             <h2>{errormessage}</h2>
@@ -21,13 +26,14 @@ const ErrorPopup = ({ErrorInfo}) => {
             <p>{statuscode}</p>
             <p>{error}</p>
 
-            <Button className="errorpopup button-container" onClick={() => setErrorPopup(false)}>Ok</Button>
+            <Button className="errorpopup button-container" onClick={() => handleClose()}>Ok</Button>
         </BaseContainer>
     );
 }
 
 ErrorPopup.propTypes = {
     ErrorInfo: PropTypes.string.isRequired,
+    resetError: PropTypes.func.isRequired
 }
 
 export default ErrorPopup;

--- a/src/components/popup-ui/ErrorPopup.tsx
+++ b/src/components/popup-ui/ErrorPopup.tsx
@@ -8,11 +8,8 @@ const ErrorPopup = ({ErrorInfo, resetError}) => {
 
     let [errorPopup, setErrorPopup] = useState(true)
     const Errordata = ErrorInfo.split("\n");
-    console.log(Errordata);
-    const requestTo = Errordata[1];
-    const statuscode = Errordata[2];
-    const error = Errordata[3];
     const errormessage = Errordata[4];
+    console.log(ErrorInfo);
 
     const handleClose = () => {
         setErrorPopup(false);
@@ -21,10 +18,7 @@ const ErrorPopup = ({ErrorInfo, resetError}) => {
 
     if (errorPopup) return (
         <BaseContainer className="errorpopup container">
-            <h2>{errormessage}</h2>
-            <p>{requestTo}</p>
-            <p>{statuscode}</p>
-            <p>{error}</p>
+            <p>{errormessage}</p>
 
             <Button className="errorpopup button-container" onClick={() => handleClose()}>Ok</Button>
         </BaseContainer>

--- a/src/components/popup-ui/ErrorPopup.tsx
+++ b/src/components/popup-ui/ErrorPopup.tsx
@@ -1,0 +1,34 @@
+import React, {useState} from "react";
+import { Button } from "components/ui/Button";
+import BaseContainer from "components/ui/BaseContainer";
+import "styles/popup-ui/ErrorPopup.scss";
+import PropTypes from "prop-types";
+
+const ErrorPopup = ({ErrorInfo}) => {
+
+    let [errorPopup, setErrorPopup] = useState(true)
+    const Errordata = ErrorInfo.split("\n");
+    console.log(Errordata);
+    const requestTo = Errordata[1];
+    const statuscode = Errordata[2];
+    const error = Errordata[3];
+    const errormessage = Errordata[4];
+
+    if (errorPopup) return (
+        <BaseContainer className="errorpopup container">
+            <h2>{errormessage}</h2>
+            <p>{requestTo}</p>
+            <p>{statuscode}</p>
+            <p>{error}</p>
+
+            <Button className="errorpopup button-container" onClick={() => setErrorPopup(false)}>Ok</Button>
+        </BaseContainer>
+    );
+}
+
+ErrorPopup.propTypes = {
+    ErrorInfo: PropTypes.string.isRequired,
+}
+
+export default ErrorPopup;
+

--- a/src/components/popup-ui/ProfilePopup.tsx
+++ b/src/components/popup-ui/ProfilePopup.tsx
@@ -23,6 +23,7 @@ const ProfilePopup = () => {
                 alert(`Something went wrong during the logout: \n${handleError(error, navigate)}`);
             }
             localStorage.removeItem("userToken");
+            localStorage.removeItem("userId")
             window.location.reload();
         }
     };

--- a/src/components/popup-ui/ProfilePopup.tsx
+++ b/src/components/popup-ui/ProfilePopup.tsx
@@ -3,10 +3,11 @@ import { Button } from "components/ui/Button";
 import BaseContainer from "components/ui/BaseContainer";
 import "styles/popup-ui/ProfilePopup.scss";
 import { useNavigate } from "react-router-dom";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 
 const ProfilePopup = () => {
     const navigate = useNavigate();
+    const { handleError } = useError();
 
     const doLogout = async () => {
         try {

--- a/src/components/popup-ui/QuitPopup.tsx
+++ b/src/components/popup-ui/QuitPopup.tsx
@@ -27,6 +27,7 @@ const QuitPopup = () => {
         } catch (error) {
             handleError(error, navigate);
             alert("Something went wrong on the server side, please try again");
+            navigate("/lobbyoverview")
         }
     };
     

--- a/src/components/popup-ui/QuitPopup.tsx
+++ b/src/components/popup-ui/QuitPopup.tsx
@@ -4,13 +4,14 @@ import BaseContainer from "components/ui/BaseContainer";
 import "styles/popup-ui/QuitPopup.scss";
 import { LobbyContext } from "../views/Lobby";
 import { GameContext } from "components/views/GameBoard/Game";
-import { api, handleError } from "../../helpers/api.js";
-import { useNavigate, useParams } from "react-router-dom";
+import { api, useError } from "../../helpers/api.js";
+import { useNavigate } from "react-router-dom";
 
 
 const QuitPopup = () => {
 
     const navigate = useNavigate();
+    const { handleError } = useError();
 
 
     const Quit = async () => {

--- a/src/components/views/AnonEnterLobbyPage.tsx
+++ b/src/components/views/AnonEnterLobbyPage.tsx
@@ -3,9 +3,10 @@ import { Button } from "components/ui/Button";
 import PropTypes from "prop-types";
 import "styles/views/AnonEnterLobby.scss";
 import Lobby from "../../models/Lobby.js";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 import { useNavigate, useParams } from "react-router-dom";
 import BaseContainer from "../ui/BaseContainer";
+
 
 const FormField = (props) => {
     return (
@@ -35,6 +36,7 @@ const AnonEnterLobbyPage = () => {
     const lobbyCode = params.lobbycode;
     const [lobby, setLobby] = useState<Lobby[]>([]);
     const [playerName, setPlayerName] = useState<String>("");
+    const { handleError } = useError();
 
     useEffect(() => {
         const fetchLobby = async () => {

--- a/src/components/views/AnonEnterLobbyPage.tsx
+++ b/src/components/views/AnonEnterLobbyPage.tsx
@@ -103,7 +103,7 @@ const AnonEnterLobbyPage = () => {
 
     return (
         <div className="container-wrapper">
-            <BaseContainer className="lobbyoverview container">
+            <BaseContainer className="base container">
                 <h2>Currently joining {lobby.name} as an anonymous user</h2>
                 <div className="player input-container">
                     Enter a playername you want to be represented as:

--- a/src/components/views/GameBoard/Game.tsx
+++ b/src/components/views/GameBoard/Game.tsx
@@ -4,7 +4,7 @@ import BaseContainer from "components/ui/BaseContainer";
 import TargetWord from "./TargetWord";
 import WordBoard from "./WordBoard";
 import PlayerList from "./PlayerList";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 import Player from "models/Player";
 import PlayerWord from "models/PlayerWord";
 import PropTypes from "prop-types";
@@ -33,6 +33,7 @@ const Game = ({ stompWebSocketHook }) => {
     const [quitPopup, setQuitPopup] = useState(false);
     const [remainingTime, setRemainingTime] = useState(" ");
     const [isLoading, setIsLoading] = useState(false);
+    const { handleError } = useError();
 
 
     const popupMessages = {

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -107,12 +107,10 @@ const LobbyPage = ({ stompWebSocketHook }) => {
     const [ownerMode, setOwnerMode] = useState(false);
     const [isEditing, setIsEditing] = useState(false);
     const [lobbyname, setLobbyname] = useState();
+    const [originalLobbyname, setOriginalLobbyname] = useState("");
     const [publicA, setPublicA] = useState();
     const [selectedTimer, setSelectedTimer] = useState(timerOptions[0].value);
-    const [selectedTimerIndex, setSelectedTimerIndex] = useState(0);
-    const [toggleTimerTriggered, setToggleTimerTriggered] = useState(false);
     const { handleError } = useError();
-
     const navigate = useNavigate();
     const params = useParams();
     const lobbycode = params.lobbycode;
@@ -206,8 +204,9 @@ const LobbyPage = ({ stompWebSocketHook }) => {
         };
         try {
             await api.put(`/lobbies/${lobbycode}`, body, config);
-        } catch (e) {
-            handleError(e);
+        } catch (error) {
+            handleError(error);
+            setLobbyname(originalLobbyname);
         }
     };
 
@@ -296,9 +295,11 @@ const LobbyPage = ({ stompWebSocketHook }) => {
 
     const handleEdit = () => {
         if (isEditing) {
+            setOriginalLobbyname(lobbyname);
             updateLobby(lobbyname, null, null, null);
             setIsEditing(false);
         } else {
+            setOriginalLobbyname(lobbyname)
             setIsEditing(true);
         }
     };

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -114,6 +114,8 @@ const LobbyPage = ({ stompWebSocketHook }) => {
     const navigate = useNavigate();
     const params = useParams();
     const lobbycode = params.lobbycode;
+    const [editError, setEditError] = useState(false);
+    const { resetError } = useError();
 
     useEffect(() => {
         // Fetch lobby and players data
@@ -204,9 +206,13 @@ const LobbyPage = ({ stompWebSocketHook }) => {
         };
         try {
             await api.put(`/lobbies/${lobbycode}`, body, config);
+
+            return true;
         } catch (error) {
             handleError(error);
-            setLobbyname(originalLobbyname);
+            setEditError(true);
+            
+            return false;
         }
     };
 
@@ -293,13 +299,19 @@ const LobbyPage = ({ stompWebSocketHook }) => {
         </div>
     );
 
-    const handleEdit = () => {
+    const handleEdit = async () => {
         if (isEditing) {
-            setOriginalLobbyname(lobbyname);
-            updateLobby(lobbyname, null, null, null);
-            setIsEditing(false);
+            const updateSuccessful = await updateLobby(
+                lobbyname,
+                null,
+                null,
+                null
+            );
+            if (updateSuccessful) {
+                setOriginalLobbyname(lobbyname);
+                setIsEditing(false);
+            }
         } else {
-            setOriginalLobbyname(lobbyname)
             setIsEditing(true);
         }
     };
@@ -308,10 +320,12 @@ const LobbyPage = ({ stompWebSocketHook }) => {
         if (isEditing) {
             return (
                 <input
-                    className="input-css"
+                    className={`input-css ${editError ? "error" : ""}`}
                     value={lobbyname}
                     onChange={(e) => {
                         setLobbyname(e.target.value);
+                        setEditError(false);
+                        resetError();
                     }}
                 />
             );

--- a/src/components/views/Lobby.tsx
+++ b/src/components/views/Lobby.tsx
@@ -9,7 +9,7 @@ import CopyButton from "../ui/CopyButton";
 import Player from "../../models/Player.js";
 import Lobby from "../../models/Lobby.js";
 import Gamemode from "../../models/GameMode.js";
-import { api, handleError } from "../../helpers/api.js";
+import { api, useError } from "../../helpers/api.js";
 import IMAGES from "../../assets/images/index1.js";
 import ICONS from "../../assets/icons/index.js";
 import hashForAnon from "../../helpers/utils";
@@ -109,6 +109,10 @@ const LobbyPage = ({ stompWebSocketHook }) => {
     const [lobbyname, setLobbyname] = useState();
     const [publicA, setPublicA] = useState();
     const [selectedTimer, setSelectedTimer] = useState(timerOptions[0].value);
+    const [selectedTimerIndex, setSelectedTimerIndex] = useState(0);
+    const [toggleTimerTriggered, setToggleTimerTriggered] = useState(false);
+    const { handleError } = useError();
+
     const navigate = useNavigate();
     const params = useParams();
     const lobbycode = params.lobbycode;

--- a/src/components/views/LobbyOverview.tsx
+++ b/src/components/views/LobbyOverview.tsx
@@ -38,7 +38,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
     const [lobbyCode, setLobbyCode] = useState<string>(null);
     const userToken = localStorage.getItem("userToken");
     const [createWithoutAccount, setCreateWithoutAccount] = useState(false);
-    const { handleError } = useError();
+    const { handleError, resetError } = useError();
 
     useEffect(() => {
         const fetchLobbies = async () => {
@@ -177,6 +177,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
                             onChange={(lobbyCode) => {
                                 setLobbyCode(lobbyCode.target.value);
                                 setSelectedLobby(null);
+                                resetError();
                             }}
                             onSubmit={joinLobby}
                         />

--- a/src/components/views/LobbyOverview.tsx
+++ b/src/components/views/LobbyOverview.tsx
@@ -10,11 +10,7 @@ import ProfilePopup from "components/popup-ui/ProfilePopup";
 import { api, useError } from "helpers/api";
 import { useNavigate } from "react-router-dom";
 
-const LobbyItem = ({
-                       lobby,
-                       onSelect,
-                       isSelected,
-                   }: {
+const LobbyItem = ({lobby, onSelect, isSelected}: {
     lobby: Lobby;
     onSelect: (lobby: Lobby) => void;
     isSelected: boolean;
@@ -109,9 +105,9 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
                 if (lobby.data.status !== "PREGAME") {
                     setlobbyIngameErrorMsg(lobby.data.name + " is currently ingame");
                     setTimeout(() => setlobbyIngameErrorMsg(""), 3000)
+
                     return
                 }
-
                 navigate("/lobby/" + lobbyCode + "/anonymous");
             } catch (error) {
                 handleError(error, navigate);
@@ -232,11 +228,9 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
                 </BaseContainer>
 
                 {loginRegisterPopup &&
-                    localStorage.getItem("userToken") === null && (
-                        <LoginRegister />)}
+                    localStorage.getItem("userToken") === null && (<LoginRegister />)}
                 {loginRegisterPopup &&
-                    localStorage.getItem("userToken") !== null && (
-                        <ProfilePopup />)}
+                    localStorage.getItem("userToken") !== null && (<ProfilePopup />)}
             </div>
             <Icon onClick={iconClick} wiggle={createWithoutAccount} />
         </div>

--- a/src/components/views/LobbyOverview.tsx
+++ b/src/components/views/LobbyOverview.tsx
@@ -7,7 +7,7 @@ import Lobby from "../../models/Lobby.js";
 import Icon from "../ui/Icon";
 import LoginRegister from "components/popup-ui/LoginRegister";
 import ProfilePopup from "components/popup-ui/ProfilePopup";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 import { useNavigate } from "react-router-dom";
 
 const LobbyItem = ({
@@ -38,6 +38,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
     const [lobbyCode, setLobbyCode] = useState<string>(null);
     const userToken = localStorage.getItem("userToken");
     const [createWithoutAccount, setCreateWithoutAccount] = useState(false);
+    const { handleError } = useError();
 
     useEffect(() => {
         const fetchLobbies = async () => {

--- a/src/components/views/LobbyOverview.tsx
+++ b/src/components/views/LobbyOverview.tsx
@@ -11,10 +11,10 @@ import { api, useError } from "helpers/api";
 import { useNavigate } from "react-router-dom";
 
 const LobbyItem = ({
-    lobby,
-    onSelect,
-    isSelected,
-}: {
+                       lobby,
+                       onSelect,
+                       isSelected,
+                   }: {
     lobby: Lobby;
     onSelect: (lobby: Lobby) => void;
     isSelected: boolean;
@@ -39,6 +39,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
     const userToken = localStorage.getItem("userToken");
     const [createWithoutAccount, setCreateWithoutAccount] = useState(false);
     const { handleError, resetError } = useError();
+    const [lobbyIngameErrorMsg, setlobbyIngameErrorMsg] = useState("");
 
     useEffect(() => {
         const fetchLobbies = async () => {
@@ -104,6 +105,13 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
     const joinLobby = async () => {
         if (!checkLogin()) {
             try {
+                const lobby = await api.get("/lobbies/" + lobbyCode);
+                if (lobby.data.status !== "PREGAME") {
+                    setlobbyIngameErrorMsg(lobby.data.name + " is currently ingame");
+                    setTimeout(() => setlobbyIngameErrorMsg(""), 3000)
+                    return
+                }
+
                 navigate("/lobby/" + lobbyCode + "/anonymous");
             } catch (error) {
                 handleError(error, navigate);
@@ -131,7 +139,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
         if (!checkLogin()) {
             setCreateWithoutAccount(true);
             setTimeout(() => setCreateWithoutAccount(false), 2000);
-            
+
             return;
         }
         try {
@@ -155,6 +163,7 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
         content = (
             <div className="lobbyoverview">
                 <ul className="lobbyoverview lobby-list">
+
                     {lobbies.map((lobby: Lobby) => (
                         <li key={lobby.code}>
                             <LobbyItem
@@ -165,6 +174,9 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
                         </li>
                     ))}
                 </ul>
+                <p className="error-message-lobby-ingame">
+                    {lobbyIngameErrorMsg}
+                </p>
                 <div>
                     <p> Or enter a lobby code: </p>
                     <form>
@@ -221,10 +233,10 @@ const LobbyOverview = ({ stompWebSocketHook }) => {
 
                 {loginRegisterPopup &&
                     localStorage.getItem("userToken") === null && (
-                    <LoginRegister />)}
+                        <LoginRegister />)}
                 {loginRegisterPopup &&
                     localStorage.getItem("userToken") !== null && (
-                    <ProfilePopup />)}
+                        <ProfilePopup />)}
             </div>
             <Icon onClick={iconClick} wiggle={createWithoutAccount} />
         </div>

--- a/src/components/views/Login.tsx
+++ b/src/components/views/Login.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { api, handleError } from "helpers/api";
+import { api } from "helpers/api";
 import User from "models/User";
 import { Button } from "components/ui/Button";
 import BaseContainer from "components/ui/BaseContainer";

--- a/src/components/views/Login.tsx
+++ b/src/components/views/Login.tsx
@@ -50,7 +50,6 @@ const Login = () => {
         } catch (error) {
             setLoginErrorMsg(error.response.data.message);
             setLoginError(true);
-            handleError(error);
         }
     };
 

--- a/src/components/views/Profile.tsx
+++ b/src/components/views/Profile.tsx
@@ -4,14 +4,13 @@ import { Button } from "components/ui/Button";
 import "styles/views/Login.scss";
 import "styles/views/Profile.scss";
 import BaseContainer from "components/ui/BaseContainer";
-import { format, isValid } from "date-fns";
+import { format } from "date-fns";
 import ProfileIcon from "components/ui/ProfileIcon";
-import { api, useError } from "helpers/api";
+import { api } from "helpers/api";
 import User from "models/User";
 
 const Profile = () => {
     const navigate = useNavigate();
-    const { handleError } = useError();
     const [username, setUsername] = useState();
     const [favourite, setFavourite] = useState(null);
     const [profilePicture, setProfilePicture] = useState();
@@ -72,7 +71,6 @@ const Profile = () => {
 
             return true;
         } catch (error) {
-            handleError(error, navigate);
             setEditError(true);
             setEditErrorMsg(error.response.data.message);
 

--- a/src/components/views/Profile.tsx
+++ b/src/components/views/Profile.tsx
@@ -6,11 +6,12 @@ import "styles/views/Profile.scss";
 import BaseContainer from "components/ui/BaseContainer";
 import { format, isValid } from "date-fns";
 import ProfileIcon from "components/ui/ProfileIcon";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 import User from "models/User";
 
 const Profile = () => {
     const navigate = useNavigate();
+    const { handleError } = useError();
     const [username, setUsername] = useState();
     const [favourite, setFavourite] = useState(null);
     const [profilePicture, setProfilePicture] = useState();
@@ -21,6 +22,7 @@ const Profile = () => {
     });
     const [editError, setEditError] = useState(false);
     const [editErrorMsg, setEditErrorMsg] = useState(" ");
+
 
     useEffect(() => {
         const fetchData = async () => {

--- a/src/components/views/Registration.tsx
+++ b/src/components/views/Registration.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { api, handleError } from "helpers/api";
+import { api } from "helpers/api";
 import User from "models/User";
 import { useNavigate } from "react-router-dom";
 import { Button } from "components/ui/Button";
@@ -66,7 +66,6 @@ const Registration = () => {
         } catch (error) {
             setRegisterErrorMsg(error.response.data.message);
             setRegisterError(true);
-            handleError(error);
         }
     };
 

--- a/src/components/views/Result.tsx
+++ b/src/components/views/Result.tsx
@@ -3,7 +3,7 @@ import "styles/views/Result.scss";
 import BaseContainer from "components/ui/BaseContainer";
 import IMAGES from "../../assets/images/index1.js";
 import { useNavigate } from "react-router-dom";
-import { api, handleError } from "helpers/api";
+import { api, useError } from "helpers/api";
 import Player from "../../models/Player.js";
 import { Button } from "components/ui/Button";
 import PropTypes from "prop-types";
@@ -23,6 +23,7 @@ const Result = ({ stompWebSocketHook }) => {
     const resultMessage = { WIN: "You Won!", LOSS: "You Lost..." };
     const [resultStatus, setResultStatus] = useState<boolean>(false);
     const [pID, setPID] = useState();
+    const { handleError } = useError();
 
     useEffect(() => {
         const fetchPlayer = async () => {

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,42 +1,65 @@
 import axios from "axios";
 import { getDomain } from "./getDomain";
+import ErrorPopup from "../components/popup-ui/ErrorPopup";
+import React, { createContext, useContext, useState } from "react";
+import PropTypes from "prop-types";
 
 export const api = axios.create({
     baseURL: getDomain(),
     headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" }
 });
 
-export const handleError = (error, navigate) => {
-    const response = error.response;
+const ErrorContext = createContext();
 
-    // catch 4xx and 5xx status codes
-    if (response && !!`${response.status}`.match(/^[4|5]\d{2}$/)) {
-        let info = `\nRequest to: ${response.request.responseURL}`;
+export const useError = () => useContext(ErrorContext);
 
-        if (response.data.status) {
-            info += `\nStatus code: ${response.data.status}`;
-            info += `\nError: ${response.data.error}`;
-            info += `\nError message: ${response.data.message}`;
+export const ErrorProvider = ({ children }) => {
+    const [errorInfo, setErrorInfo] = useState(null);
+
+    const handleError = (error, navigate) => {
+        const response = error.response;
+
+        // catch 4xx and 5xx status codes
+        if (response && !!`${response.status}`.match(/^[4|5]\d{2}$/)) {
+            let info = `\nRequest to: ${response.request.responseURL}`;
+
+            if (response.data.status) {
+                info += `\nStatus code: ${response.data.status}`;
+                info += `\nError: ${response.data.error}`;
+                info += `\n${response.data.message}`;
+            } else {
+                info += `\nStatus code: ${response.status}`;
+                info += `\n${response.data}`;
+            }
+
+            error.response.statusText = response.data.message;
+            console.log("The request was made and answered but was unsuccessful.", error.response);
+            setErrorInfo(info);
+
+            return info;
         } else {
-            info += `\nStatus code: ${response.status}`;
-            info += `\nError message:\n${response.data}`;
-        }
+            if (error.message.match(/Network Error/i)) {
+                localStorage.clear();
+                alert("The server cannot be reached.\nDid you start it?");
+                navigate("/server-down/");
 
-        error.response.statusText = response.data.message;
-        console.log("The request was made and answered but was unsuccessful.", error.response);
+                return error.message;
+            }
 
-        return info;
-    } else {
-        if (error.message.match(/Network Error/i)) {
-            localStorage.clear();
-            alert("The server cannot be reached.\nDid you start it?");
-            navigate("/server-down/");
-            
+            console.log("Something else happened.", error);
+
             return error.message;
         }
-        
-        console.log("Something else happened.", error);
+    };
 
-        return error.message;
-    }
+    return (
+        <ErrorContext.Provider value={{ handleError }}>
+            {children}
+            {errorInfo && <ErrorPopup ErrorInfo={errorInfo} />}
+        </ErrorContext.Provider>
+    );
 };
+
+ErrorProvider.propTypes = {
+    children: PropTypes.node.isRequired,
+}

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -55,7 +55,7 @@ export const ErrorProvider = ({ children }) => {
     return (
         <ErrorContext.Provider value={{ handleError }}>
             {children}
-            {errorInfo && <ErrorPopup ErrorInfo={errorInfo} />}
+            {errorInfo && <ErrorPopup ErrorInfo={errorInfo} resetError={() => setErrorInfo(false)} />}
         </ErrorContext.Provider>
     );
 };

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -22,6 +22,7 @@ export const handleError = (error, navigate) => {
             info += `\nError message:\n${response.data}`;
         }
 
+        error.response.statusText = response.data.message;
         console.log("The request was made and answered but was unsuccessful.", error.response);
 
         return info;

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { getDomain } from "./getDomain";
 import ErrorPopup from "../components/popup-ui/ErrorPopup";
-import React, { createContext, useContext, useState } from "react";
+import React, {createContext, useContext, useMemo, useState} from "react";
 import PropTypes from "prop-types";
 
 export const api = axios.create({
@@ -54,8 +54,10 @@ export const ErrorProvider = ({ children }) => {
 
     const resetError = () => setErrorInfo(null);
 
+    const error = useMemo(() => ({ handleError, resetError }), []);
+
     return (
-        <ErrorContext.Provider value={{ handleError, resetError }}>
+        <ErrorContext.Provider value={error}>
             {children}
             {errorInfo && <ErrorPopup ErrorInfo={errorInfo} resetError={resetError} />}
         </ErrorContext.Provider>

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -52,10 +52,12 @@ export const ErrorProvider = ({ children }) => {
         }
     };
 
+    const resetError = () => setErrorInfo(null);
+
     return (
-        <ErrorContext.Provider value={{ handleError }}>
+        <ErrorContext.Provider value={{ handleError, resetError }}>
             {children}
-            {errorInfo && <ErrorPopup ErrorInfo={errorInfo} resetError={() => setErrorInfo(false)} />}
+            {errorInfo && <ErrorPopup ErrorInfo={errorInfo} resetError={resetError} />}
         </ErrorContext.Provider>
     );
 };

--- a/src/styles/popup-ui/ErrorPopup.scss
+++ b/src/styles/popup-ui/ErrorPopup.scss
@@ -11,11 +11,11 @@
       border-radius: $borderRadius;
       max-width: 350px;
       border: black solid 3px;
-
       text-align: center;
       display: flex;
       flex-direction: column;
       align-items: center;
+      padding: 20px;
 
     }
 
@@ -23,6 +23,8 @@
       margin-top: 5px;
       margin-bottom: 5px;
       font-size: 1.2em;
+      color: darkred;
+      padding-bottom: 10px;
     }
 
     h2 {
@@ -36,7 +38,7 @@
       gap: 1em;
       align-items: center;
       width: 50%;
-      margin: 10px;
+
     }
 
   }

--- a/src/styles/popup-ui/ErrorPopup.scss
+++ b/src/styles/popup-ui/ErrorPopup.scss
@@ -1,0 +1,42 @@
+  @import "../theme";
+
+  .errorpopup {
+    &.container {
+      z-index: 6;
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: $background;
+      border-radius: $borderRadius;
+      max-width: 350px;
+      border: black solid 3px;
+
+      text-align: center;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
+    }
+
+    p {
+      margin-top: 5px;
+      margin-bottom: 5px;
+      font-size: 1.2em;
+    }
+
+    h2 {
+      color: lighten($textColor, 60);
+    }
+
+    &.button-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      gap: 1em;
+      align-items: center;
+      width: 50%;
+      margin: 10px;
+    }
+
+  }

--- a/src/styles/views/AnonEnterLobby.scss
+++ b/src/styles/views/AnonEnterLobby.scss
@@ -7,7 +7,7 @@
   for more information visit https://sass-lang.com/guide
  */
 
-.lobbyoverview {
+.base {
   &.container {
     z-index: 1;
     background: $background;

--- a/src/styles/views/Lobby.scss
+++ b/src/styles/views/Lobby.scss
@@ -23,10 +23,16 @@
     padding-bottom: 2em;
   }
 
-  & p,
-  h2 {
+  & p {
     margin: 0.5em 0;
     text-decoration: underline;
+  }
+
+  & h2 {
+    margin: 0.5em 0;
+    text-decoration: underline;
+    font-size: 30px;
+    transform: translateX(15%);
   }
 
   &.game-and-players-container {

--- a/src/styles/views/Lobby.scss
+++ b/src/styles/views/Lobby.scss
@@ -265,3 +265,12 @@
   font-size: 14px;
   font-family: $fontDefault;
 }
+
+.error-message-lobby {
+  min-height: 20px;
+  z-index: 999999;
+  color:rgb(151, 0, 0);
+  font-size: 16px;
+  left: 20px;
+  position: relative;
+}

--- a/src/styles/views/LobbyOverview.scss
+++ b/src/styles/views/LobbyOverview.scss
@@ -36,9 +36,13 @@
         justify-content: center;
     }
 
-    & p,
-    h2 {
+    & p {
         margin: 0.5em 0;
+    }
+
+    & h2 {
+        margin: 0.5em 0;
+        font-size:30px;
     }
 
     @media only screen and (max-width: 768px) {

--- a/src/styles/views/LobbyOverview.scss
+++ b/src/styles/views/LobbyOverview.scss
@@ -8,6 +8,7 @@
  */
 
 .lobbyoverview {
+    margin-top: 0;
     &.container {
         z-index: 1;
         background: $background;
@@ -38,6 +39,7 @@
 
     & p {
         margin: 0.5em 0;
+        text-align: center;
     }
 
     & h2 {
@@ -113,6 +115,14 @@
 
         }
     }
+}
+
+.error-message-lobby-ingame {
+    min-height: 20px;
+    color:rgb(151, 0, 0);
+    right: 30px;
+    margin-top: -10px;
+    text-align: center;
 }
 
 .container-wrapper {


### PR DESCRIPTION
I added a popup which is rendered whenever the client tries to do something that is not allowed / an error is thrown. There are cases where the popup is not shown (such as in login page) where there already is red text displayed when the user does not exist. The popup can be checked and should always appear in cases where an error is made and no other specific message is specified. To test these and check out the popups, you can try joining an already running lobby or try to join with a lobby url that does not exist. 